### PR TITLE
asofjoin + associated unit tests refactoring

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -137,10 +137,10 @@ class AsOfJoinTest(SparkTest):
         dfExpected = self.buildTestDF(expectedSchema, expected_data, ["left_event_ts", "right_event_ts"])
 
         # perform the join
-        tsdf_left = TSDF(dfLeft, ts_col="event_ts",partitionCols=["symbol"])
-        tsdf_right = TSDF(dfRight, ts_col="event_ts", partitionCols=["symbol"])
+        tsdf_left = TSDF(dfLeft, ts_col="event_ts",partition_cols=["symbol"])
+        tsdf_right = TSDF(dfRight, ts_col="event_ts", partition_cols=["symbol"])
 
-        joined_df = tsdf_left.asofJoin(tsdf_right).df
+        joined_df = tsdf_left.asofJoin(tsdf_right, left_prefix="left", right_prefix="right").df
 
         # joined dataframe should equal the expected dataframe
         self.assertDataFramesEqual(joined_df, dfExpected)
@@ -190,10 +190,12 @@ class AsOfJoinTest(SparkTest):
         dfRight = self.buildTestDF(rightSchema, right_data)
         dfExpected = self.buildTestDF(expectedSchema, expected_data, ["left_event_ts", "right_event_ts"])
 
-        tsdf_left = TSDF(dfLeft, ts_col="event_ts", partitionCols=["symbol"])
-        tsdf_right = TSDF(dfRight, ts_col="event_ts", partitionCols=["symbol"])
+        tsdf_left = TSDF(dfLeft, ts_col="event_ts", partition_cols=["symbol"])
+        tsdf_right = TSDF(dfRight, ts_col="event_ts", partition_cols=["symbol"])
 
-        joined_df = tsdf_left.asofJoin(tsdf_right, tsPartitionVal = 10, fraction = 0.1).df
+        joined_df = tsdf_left.asofJoin(tsdf_right, left_prefix="left", right_prefix="right",
+                                       tsPartitionVal = 10, fraction = 0.1).df
+
         self.assertDataFramesEqual(joined_df, dfExpected)
 
 
@@ -231,7 +233,7 @@ class RangeStatsTest(SparkTest):
         dfExpected = self.buildTestDF(expectedSchema,expected_data)
 
         # convert to TSDF
-        tsdf_left = TSDF(df, partitionCols=["symbol"])
+        tsdf_left = TSDF(df, partition_cols=["symbol"])
 
         # using lookback of 20 minutes
         featured_df = tsdf_left.withRangeStats(rangeBackWindowSecs=1200).df


### PR DESCRIPTION
This PR contains a complete refactoring of the asofJoin method. The main changes are:

Refactoring:
* Breaking down the asofJoin in smaller, more readable methods.
* Each method to take in and return an instance of the TSDF class
* All pyspark.sql.functions now make use of the "f" prefix.

Functionality:
* Removed the "joining back" part of the asofJoin. Instead I have opted to call f.last() method on each of the columns of the right dataframe. in terms of Spark performance this will only lead to one sort in the sparkplan.
  * Note: One danger is that the physical plan may grow too large for too many columns on the right side of the join. This can potentially be circumvented by making use of a struct column, as opposed to making use of reduce + f.last which is happening now.

Tests:
* Added a test for the partitioned asof join.