### PR TITLE
Parameterize null value skipping behavior in as-of join

### DIFF
--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -236,7 +236,13 @@ class AsOfJoinTest(SparkTest):
                       ["S1", "2020-09-01 00:02:01", None, None],
                       ["S1", "2020-09-01 00:15:01", 359.21, 365.31]]
 
-        expected_data = [
+        expected_data_skip_nulls = [
+            ["S1", "2020-08-01 00:00:10", 349.21, "2020-08-01 00:00:01", 345.11, 351.12],
+            ["S1", "2020-08-01 00:01:12", 351.32, "2020-08-01 00:01:05", 345.11, 353.13],
+            ["S1", "2020-09-01 00:02:10", 361.1, "2020-09-01 00:02:01", 345.11, 353.13],
+            ["S1", "2020-09-01 00:19:12", 362.1, "2020-09-01 00:15:01", 359.21, 365.31]]
+
+        expected_data_skip_nulls_disabled = [
             ["S1", "2020-08-01 00:00:10", 349.21, "2020-08-01 00:00:01", 345.11, 351.12],
             ["S1", "2020-08-01 00:01:12", 351.32, "2020-08-01 00:01:05", None, 353.13],
             ["S1", "2020-09-01 00:02:10", 361.1, "2020-09-01 00:02:01", None, None],
@@ -245,16 +251,27 @@ class AsOfJoinTest(SparkTest):
         # Construct dataframes
         dfLeft = self.buildTestDF(leftSchema, left_data)
         dfRight = self.buildTestDF(rightSchema, right_data)
-        dfExpected = self.buildTestDF(expectedSchema, expected_data, ["left_event_ts", "right_event_ts"])
+        dfExpectedSkipNulls = self.buildTestDF(
+            expectedSchema, expected_data_skip_nulls, ["left_event_ts", "right_event_ts"]
+        )
+        dfExpectedSkipNullsDisabled = self.buildTestDF(
+            expectedSchema, expected_data_skip_nulls_disabled, ["left_event_ts", "right_event_ts"]
+        )
 
-        # perform the join
         tsdf_left = TSDF(dfLeft, ts_col="event_ts", partition_cols=["symbol"])
         tsdf_right = TSDF(dfRight, ts_col="event_ts", partition_cols=["symbol"])
 
+        # perform the join with skip nulls enabled (default)
+        joined_df = tsdf_left.asofJoin(tsdf_right, left_prefix="left", right_prefix="right").df
+
+        # joined dataframe should equal the expected dataframe with nulls skipped
+        self.assertDataFramesEqual(joined_df, dfExpectedSkipNulls)
+
+        # perform the join with skip nulls disabled
         joined_df = tsdf_left.asofJoin(tsdf_right, left_prefix="left", right_prefix="right", skipNulls=False).df
 
-        # joined dataframe should equal the expected dataframe
-        self.assertDataFramesEqual(joined_df, dfExpected)
+        # joined dataframe should equal the expected dataframe without nulls skipped
+        self.assertDataFramesEqual(joined_df, dfExpectedSkipNullsDisabled)
 
     def test_sequence_number_sort(self):
         """Skew AS-OF Join with Partition Window Test"""

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -208,6 +208,54 @@ class AsOfJoinTest(SparkTest):
         # joined dataframe should equal the expected dataframe
         self.assertDataFramesEqual(joined_df, dfExpected)
 
+    def test_asof_join_skip_nulls_disabled(self):
+        """AS-OF Join with skip nulls disabled"""
+        leftSchema = StructType([StructField("symbol", StringType()),
+                                 StructField("event_ts", StringType()),
+                                 StructField("trade_pr", FloatType())])
+
+        rightSchema = StructType([StructField("symbol", StringType()),
+                                  StructField("event_ts", StringType()),
+                                  StructField("bid_pr", FloatType()),
+                                  StructField("ask_pr", FloatType())])
+
+        expectedSchema = StructType([StructField("symbol", StringType()),
+                                     StructField("left_event_ts", StringType()),
+                                     StructField("left_trade_pr", FloatType()),
+                                     StructField("right_event_ts", StringType()),
+                                     StructField("right_bid_pr", FloatType()),
+                                     StructField("right_ask_pr", FloatType())])
+
+        left_data = [["S1", "2020-08-01 00:00:10", 349.21],
+                     ["S1", "2020-08-01 00:01:12", 351.32],
+                     ["S1", "2020-09-01 00:02:10", 361.1],
+                     ["S1", "2020-09-01 00:19:12", 362.1]]
+
+        right_data = [["S1", "2020-08-01 00:00:01", 345.11, 351.12],
+                      ["S1", "2020-08-01 00:01:05", None, 353.13],
+                      ["S1", "2020-09-01 00:02:01", None, None],
+                      ["S1", "2020-09-01 00:15:01", 359.21, 365.31]]
+
+        expected_data = [
+            ["S1", "2020-08-01 00:00:10", 349.21, "2020-08-01 00:00:01", 345.11, 351.12],
+            ["S1", "2020-08-01 00:01:12", 351.32, "2020-08-01 00:01:05", None, 353.13],
+            ["S1", "2020-09-01 00:02:10", 361.1, "2020-09-01 00:02:01", None, None],
+            ["S1", "2020-09-01 00:19:12", 362.1, "2020-09-01 00:15:01", 359.21, 365.31]]
+
+        # Construct dataframes
+        dfLeft = self.buildTestDF(leftSchema, left_data)
+        dfRight = self.buildTestDF(rightSchema, right_data)
+        dfExpected = self.buildTestDF(expectedSchema, expected_data, ["left_event_ts", "right_event_ts"])
+
+        # perform the join
+        tsdf_left = TSDF(dfLeft, ts_col="event_ts", partition_cols=["symbol"])
+        tsdf_right = TSDF(dfRight, ts_col="event_ts", partition_cols=["symbol"])
+
+        joined_df = tsdf_left.asofJoin(tsdf_right, left_prefix="left", right_prefix="right", skipNulls=False).df
+
+        # joined dataframe should equal the expected dataframe
+        self.assertDataFramesEqual(joined_df, dfExpected)
+
     def test_sequence_number_sort(self):
         """Skew AS-OF Join with Partition Window Test"""
         leftSchema = StructType([StructField("symbol", StringType()),


### PR DESCRIPTION
This PR exposes a new optional parameter `skipNulls` that determines whether null values should be skipped when performing the as-of join. It is `True` by default to preserve existing behavior. The `skipNulls` value is passed to the `ignoreNulls` argument in Spark's `last` function:  https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.functions.last.html

TODO: 
- [ ] Document parameter in README