### PR TITLE
Speed up windowing in __generate_target_fill & __generate_column_time_fill

### DIFF
--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -1,4 +1,3 @@
-import sys
 from typing import List
 
 from pyspark.sql.dataframe import DataFrame
@@ -210,14 +209,14 @@ class Interpolation:
             last(col(f"{ts_col}_{target_col}"), ignorenulls=True).over(
                 Window.partitionBy(*partition_cols)
                 .orderBy(ts_col)
-                .rowsBetween(-sys.maxsize, 0)
+                .rowsBetween(Window.unboundedPreceding, 0)
             ),
         ).withColumn(
             f"next_timestamp_{target_col}",
             first(col(f"{ts_col}_{target_col}"), ignorenulls=True).over(
                 Window.partitionBy(*partition_cols)
                 .orderBy(ts_col)
-                .rowsBetween(0, sys.maxsize)
+                .rowsBetween(0, Window.unboundedFollowing)
             ),
         )
 
@@ -238,7 +237,7 @@ class Interpolation:
                 last(df[target_col], ignorenulls=True).over(
                     Window.partitionBy(*partition_cols)
                     .orderBy(ts_col)
-                    .rowsBetween(-sys.maxsize, 0)
+                    .rowsBetween(Window.unboundedPreceding, 0)
                 ),
             )
             # Handle if subsequent value is null
@@ -247,7 +246,7 @@ class Interpolation:
                 first(df[target_col], ignorenulls=True).over(
                     Window.partitionBy(*partition_cols)
                     .orderBy(ts_col)
-                    .rowsBetween(0, sys.maxsize)
+                    .rowsBetween(0, Window.unboundedFollowing)
                 ),
             ).withColumn(
                 f"next_{target_col}",

--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -241,12 +241,14 @@ class Interpolation:
                 ),
             )
             # Handle if subsequent value is null
+            # We use last+orderBy(col(ts_col).desc()) instead of first+orderBy(
+            # ts_col) because of https://issues.apache.org/jira/browse/SPARK-36844
             .withColumn(
                 f"next_null_{target_col}",
-                first(df[target_col], ignorenulls=True).over(
+                last(df[target_col], ignorenulls=True).over(
                     Window.partitionBy(*partition_cols)
-                    .orderBy(ts_col)
-                    .rowsBetween(0, Window.unboundedFollowing)
+                    .orderBy(col(ts_col).desc())
+                    .rowsBetween(Window.unboundedPreceding, 0)
                 ),
             ).withColumn(
                 f"next_{target_col}",

--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -213,10 +213,12 @@ class Interpolation:
             ),
         ).withColumn(
             f"next_timestamp_{target_col}",
-            first(col(f"{ts_col}_{target_col}"), ignorenulls=True).over(
+            # last+orderBy-desc instead of first because of
+            # https://issues.apache.org/jira/browse/SPARK-36844
+            last(col(f"{ts_col}_{target_col}"), ignorenulls=True).over(
                 Window.partitionBy(*partition_cols)
-                .orderBy(ts_col)
-                .rowsBetween(0, Window.unboundedFollowing)
+                .orderBy(col(ts_col).desc())
+                .rowsBetween(Window.unboundedPreceding, 0)
             ),
         )
 


### PR DESCRIPTION
There is [a bug ](https://issues.apache.org/jira/browse/SPARK-36844) in spark which makes first+unboundedFollowing significantly slower than last+unboundedPreceding. Tempo uses first+unboundedFollowing in the interpolation code, and I rewrote it to sort use last+unboundedPreceding instead by sorting descending first. 

Below is an example showing the difference.

```python
# Databricks notebook source
# MAGIC %pip install dbl-tempo

# COMMAND ----------

from typing import List
from pyspark.sql.functions import col, expr, first, last, lead, lit, when
from pyspark.sql.dataframe import DataFrame
from pyspark.sql.window import Window

#The new implementation

def __generate_target_fill(
    self, df: DataFrame, partition_cols: List[str], ts_col: str, target_col: str
) -> DataFrame:
    """
    Create columns for previous and next value for a specific target column
    :param df  - input DataFrame
    :param partition_cols   - partition column names
    :param ts_col   - timestamp column name
    :param target_col   - target column name
    """
    return (
        df.withColumn(
            f"previous_{target_col}",
            last(df[target_col], ignorenulls=True).over(
                Window.partitionBy(*partition_cols)
                .orderBy(ts_col)
                .rowsBetween(Window.unboundedPreceding, 0)
            ),
        )
        # Handle if subsequent value is null
        # We use last+orderBy(col(ts_col).desc()) instead of first+orderBy(
        # ts_col) because of https://issues.apache.org/jira/browse/SPARK-36844
        .withColumn(
            f"next_null_{target_col}",
            last(df[target_col], ignorenulls=True).over(
                Window.partitionBy(*partition_cols)
                .orderBy(col(ts_col).desc())
                .rowsBetween(Window.unboundedPreceding, 0)
            ),
        ).withColumn(
            f"next_{target_col}",
            lead(df[target_col]).over(
                Window.partitionBy(*partition_cols).orderBy(ts_col)
            ),
        )
    )
# New implementation end


# COMMAND ----------

# Beginning benchmarking new vs old implementation:
from importlib.metadata import version
from pyspark.mllib.random import RandomRDDs
from tempo.interpol import Interpolation
import pyspark.sql.functions as F
import timeit


print(f"tempo version: {version('dbl-tempo')}")
print(f"Spark version: {spark.version}")

# To generate some test-data
def generate_random_uniform_df(nrows, ncols):
    df  = RandomRDDs.uniformVectorRDD(spark.sparkContext, nrows,ncols).map(lambda a : a.tolist()).toDF()
    return df

# 40 000 random vals + 10 000 None's
test_df = generate_random_uniform_df(40000,2).union(generate_random_uniform_df(10000,2).withColumn("_2", F.lit(None)))

before=timeit.default_timer()
new_res=__generate_target_fill(self=None, df=test_df, partition_cols=[], ts_col="_1", target_col="_2").collect()
print(f"New method took {timeit.default_timer()-before} seconds")

before=timeit.default_timer()
old_res=Interpolation(test_df)._Interpolation__generate_target_fill(df=test_df, partition_cols=[], ts_col="_1", target_col="_2").collect()
print(f"Old method took {timeit.default_timer()-before} seconds")

print(f"Old and new method gives same result: {new_res==old_res}")
```
Output:
```
tempo version: 0.1.7
Spark version: 3.2.1
New method took 1.299080867000157 seconds
Old method took 52.683910931000355 seconds
Old and new method gives same result: True
```

The only issue is if there are some nuances making the two approaches semantically different, but I lack the overview of the code at large to determine if this is the case, so please give it a proper review ;-)

