### PR TITLE
Use latest tag as build version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,4 @@ pytz==2021.3
 scipy==1.8.0
 six==1.16.0
 wheel==0.37.1
+semver==2.13.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,12 +1,36 @@
-import setuptools
-from setuptools import find_packages
+import subprocess
+import re
+from setuptools import find_packages, setup
+import semver
 
+
+# run a shell command and return stdout
+def run_cmd(cmd):
+    cmd_proc = subprocess.run(cmd, shell=True, capture_output=True)
+    if cmd_proc.returncode != 0:
+        raise OSError(f"Shell command '{cmd}' failed with return code {cmd_proc.returncode}\n"
+                      f"STDERR: {cmd_proc.stderr.decode('utf-8')}")
+    return cmd_proc.stdout.decode('utf-8').strip()
+
+
+#
+# fetch the most recent version tag to use as build version
+#
+latest_tag = run_cmd('git describe --abbrev=0 --tags')
+build_version = re.sub('v\.?\s*', '', latest_tag)
+# validate that this is a valid semantic version - will throw exception if not
+semver.VersionInfo.parse(build_version)
+
+# use the contents of the README file as the 'long description' for the package
 with open('./README.md', 'r') as fh:
     long_description = fh.read()
 
-setuptools.setup(
+#
+# build the package
+#
+setup(
     name='dbl-tempo',
-    version='0.1.10',
+    version=build_version,
     author='Ricardo Portilla, Tristan Nixon, Max Thone, Sonali Guleria',
     author_email='labs@databricks.com',
     description='Spark Time Series Utility Package',
@@ -15,14 +39,14 @@ setuptools.setup(
     url='https://github.com/databrickslabs/tempo',
     packages=find_packages(where=".", include=["tempo"]),
     install_requires=[
-     'ipython',
-     'pandas',
-     'scipy'
+        'ipython',
+        'pandas',
+        'scipy'
     ],
     extras_require=dict(tests=["pytest"]),
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: Other/Proprietary License',
         'Operating System :: OS Independent',
-        ],
-    )
+    ],
+)


### PR DESCRIPTION
I've updated the `setup.py` to make use of the latest tag on a branch as the build version. This will allow us to control release versioning through the git tags we apply, and still go back to older versions and re-build them with the correct version. We will still need to remember to apply an appropriate version tag (and increment the number correctly). I will look for some reminder to do this in the PR mechanism, perhaps.