### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,8 @@ name: docs
 
 on:
   push:
-    branches: [ '*' ]
-    #tags:
-    #  - 'v*' # only release a versioned tag, such as v.X.Y.Z
+    tags:
+      - 'v*' # only release a versioned tag, such as v.X.Y.Z
 
 jobs:
   build-docs:
@@ -37,7 +36,7 @@ jobs:
           path: docs/_build/html/
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
-        if: $${{ github.ref }} == 'refs/heads/fix_docs_build'
+        if: $${{ github.ref }} == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,9 @@ name: docs
 
 on:
   push:
-    tags:
-      - 'v*' # only release a versioned tag, such as v.X.Y.Z
+    branches: [ '*' ]
+    #tags:
+    #  - 'v*' # only release a versioned tag, such as v.X.Y.Z
 
 jobs:
   build-docs:
@@ -36,7 +37,7 @@ jobs:
           path: docs/_build/html/
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        #if: $${{ github.ref }} == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           path: docs/_build/html/
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
-        #if: $${{ github.ref }} == 'refs/heads/master'
+        if: $${{ github.ref }} == 'refs/heads/fix_docs_build'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html


### PR DESCRIPTION
There was a minor syntax issue in the docs workflow that prevented the deployment task from running. This should fix the rule, and we should get updated docs on every release.