### PR TITLE
build & test of code should run on all PRs to master. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,11 @@
 name: build
+
 on:
   push:
-    branches: '*'
+    branches: [ '*' ]
+  pull_request:
+    branches: [ 'master' ]
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Currently they do not run when Dependabot creates a PR to update a package version.
This creates a potential for a package update to break code.