### PR TITLE
Chore: Add warning when resampling or interpolating for long time horizons

### DIFF
--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -18,7 +18,7 @@ class Interpolation:
         """
         Validate if the fill provided is within the allowed list of values.
 
-        :param fill - Fill type e.g. "zero", "null", "bfill", "ffill", "linear"
+        :param fill: Fill type e.g. "zero", "null", "bfill", "ffill", "linear"
         """
         if method not in method_options:
             raise ValueError(
@@ -35,10 +35,10 @@ class Interpolation:
         """
         Validate if target column exists and is of numeric type, and validates if partition column exists.
 
-        :param df -  DataFrame to be validated
-        :param partition_cols -  Partition columns to be validated
-        :param target_col -  Target column to be validated
-        :param ts_col -  Timestamp column to be validated
+        :param df: DataFrame to be validated
+        :param partition_cols: Partition columns to be validated
+        :param target_col: Target column to be validated
+        :param ts_col: Timestamp column to be validated
         """
 
         for column in partition_cols:
@@ -68,9 +68,9 @@ class Interpolation:
         """
         Native Spark function for calculating linear interpolation on a DataFrame.
 
-        :param df  - prepared dataframe to be interpolated
-        :param ts_col  - timeseries column name
-        :param target_col  - column to be interpolated
+        :param df: prepared dataframe to be interpolated
+        :param ts_col: timeseries column name
+        :param target_col: column to be interpolated
         """
         interpolation_expr = f"""
         case when is_interpolated_{target_col} = false then {target_col}
@@ -104,10 +104,10 @@ class Interpolation:
         """
         Apply interpolation to column.
 
-        :param series  - input DataFrame
-        :param ts_col   - timestamp column name
-        :param target_col   - column to interpolate
-        :param method   - interpolation function to fill missing values
+        :param series: input DataFrame
+        :param ts_col: timestamp column name
+        :param target_col: column to interpolate
+        :param method: interpolation function to fill missing values
         """
         output_df: DataFrame = series
 
@@ -186,9 +186,9 @@ class Interpolation:
         """
         Create additional timeseries columns for previous and next timestamps
 
-        :param df  - input DataFrame
-        :param partition_cols   - partition column names
-        :param ts_col   - timestamp column name
+        :param df: input DataFrame
+        :param partition_cols: partition column names
+        :param ts_col: timestamp column name
         """
         return df.withColumn("previous_timestamp", col(ts_col),).withColumn(
             "next_timestamp",
@@ -201,10 +201,10 @@ class Interpolation:
         """
         Create timeseries columns for previous and next timestamps for a specific target column
 
-        :param df  - input DataFrame
-        :param partition_cols   - partition column names
-        :param ts_col   - timestamp column name
-        :param target_col   - target column name
+        :param df: input DataFrame
+        :param partition_cols: partition column names
+        :param ts_col: timestamp column name
+        :param target_col: target column name
         """
         return df.withColumn(
             f"previous_timestamp_{target_col}",
@@ -228,10 +228,10 @@ class Interpolation:
         """
         Create columns for previous and next value for a specific target column
 
-        :param df  - input DataFrame
-        :param partition_cols   - partition column names
-        :param ts_col   - timestamp column name
-        :param target_col   - target column name
+        :param df: input DataFrame
+        :param partition_cols: partition column names
+        :param ts_col: timestamp column name
+        :param target_col: target column name
         """
         return (
             df.withColumn(
@@ -270,17 +270,17 @@ class Interpolation:
         show_interpolated: bool,
     ) -> DataFrame:
         """
-        Apply interpolation.
+        Apply interpolation function.
 
-        :param tsdf  - input TSDF
-        :param ts_col   - timestamp column name
-        :param target_cols   - numeric columns to interpolate
-        :param partition_cols  - partition columns names
-        :param freq  - frequency at which to sample
-        :param func   - aggregate function used for sampling to the specified interval
-        :param method   - interpolation function usded to fill missing values
-        :param show_interpolated  - show if row is interpolated?
-        :return DataFrame
+        :param tsdf: input TSDF
+        :param ts_col: timestamp column name
+        :param target_cols: numeric columns to interpolate
+        :param partition_cols: partition columns names
+        :param freq: frequency at which to sample
+        :param func: aggregate function used for sampling to the specified interval
+        :param method: interpolation function usded to fill missing values
+        :param show_interpolated: show if row is interpolated?
+        :return: DataFrame containing interpolated data.
         """
         # Validate input parameters
         self.__validate_fill(method)

--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -287,12 +287,12 @@ class Interpolation:
         self.__validate_fill(method)
         self.__validate_col(tsdf.df, partition_cols, target_cols, ts_col)
 
-        # Throw warning for user to validate that the expected number of output rows is valid.
-        calculate_time_horizon(tsdf.df, ts_col, freq)
-
         # Convert Frequency using resample dictionary
         parsed_freq = checkAllowableFreq(freq)
         freq = f"{parsed_freq[0]} {freq_dict[parsed_freq[1]]}"
+
+        # Throw warning for user to validate that the expected number of output rows is valid.
+        calculate_time_horizon(tsdf.df, ts_col, freq, partition_cols)
 
         # Only select required columns for interpolation
         input_cols: List[str] = [*partition_cols, ts_col, *target_cols]

--- a/python/tempo/interpol.py
+++ b/python/tempo/interpol.py
@@ -3,6 +3,7 @@ from typing import List
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import col, expr, last, lead, lit, when
 from pyspark.sql.window import Window
+from tempo.utils import calculate_time_horizon
 from tempo.resample import checkAllowableFreq, freq_dict
 
 # Interpolation fill options
@@ -285,6 +286,9 @@ class Interpolation:
         # Validate input parameters
         self.__validate_fill(method)
         self.__validate_col(tsdf.df, partition_cols, target_cols, ts_col)
+
+        # Throw warning for user to validate that the expected number of output rows is valid.
+        calculate_time_horizon(tsdf.df, ts_col, freq)
 
         # Convert Frequency using resample dictionary
         parsed_freq = checkAllowableFreq(freq)

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -682,7 +682,11 @@ class TSDF:
     :return: TSDF object with sample data using aggregate function
     """
     rs.validateFuncExists(func)
-    calculate_time_horizon(self.df, self.ts_col, freq)
+
+    # Throw warning for user to validate that the expected number of output rows is valid.
+    if fill is True:
+        calculate_time_horizon(self.df, self.ts_col, freq)
+        
     enriched_df:DataFrame = rs.aggregate(self, freq, func, metricCols, prefix, fill)
     return (_ResampledTSDF(enriched_df, ts_col = self.ts_col, partition_cols = self.partitionCols, freq = freq, func = func))
 

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -687,7 +687,7 @@ class TSDF:
 
   def interpolate(self, freq: str, func: str, method: str, target_cols: List[str] = None,ts_col: str = None, partition_cols: List[str]=None, show_interpolated:bool = False):
     """
-    function to interpolate based on frequency, aggregation, and fill similar to pandas. Data will first be aggregated using resample, then missing values
+    Function to interpolate based on frequency, aggregation, and fill similar to pandas. Data will first be aggregated using resample, then missing values
     will be filled based on the fill calculation.
 
     :param freq: frequency for upsample - valid inputs are "hr", "min", "sec" corresponding to hour, minute, or second
@@ -820,7 +820,7 @@ class _ResampledTSDF(TSDF):
 
     def interpolate(self, method: str, target_cols: List[str] = None, show_interpolated:bool = False):
       """
-      function to interpolate based on frequency, aggregation, and fill similar to pandas. This method requires an already sampled data set in order to use.
+      Function to interpolate based on frequency, aggregation, and fill similar to pandas. This method requires an already sampled data set in order to use.
 
       :param method: function used to fill missing values e.g. linear, null, zero, bfill, ffill
       :param target_cols [optional]: columns that should be interpolated, by default interpolates all numeric columns

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -14,7 +14,7 @@ from scipy.fft import fft, fftfreq
 import tempo.io as tio
 import tempo.resample as rs
 from tempo.interpol import Interpolation
-from tempo.utils import ENV_BOOLEAN, PLATFORM
+from tempo.utils import ENV_BOOLEAN, PLATFORM, calculate_time_horizon
 
 logger = logging.getLogger(__name__)
 
@@ -682,6 +682,7 @@ class TSDF:
     :return: TSDF object with sample data using aggregate function
     """
     rs.validateFuncExists(func)
+    calculate_time_horizon(self.df, self.ts_col, freq)
     enriched_df:DataFrame = rs.aggregate(self, freq, func, metricCols, prefix, fill)
     return (_ResampledTSDF(enriched_df, ts_col = self.ts_col, partition_cols = self.partitionCols, freq = freq, func = func))
 

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -685,8 +685,8 @@ class TSDF:
 
     # Throw warning for user to validate that the expected number of output rows is valid.
     if fill is True:
-        calculate_time_horizon(self.df, self.ts_col, freq)
-        
+        calculate_time_horizon(self.df, self.ts_col, freq, self.partitionCols)
+
     enriched_df:DataFrame = rs.aggregate(self, freq, func, metricCols, prefix, fill)
     return (_ResampledTSDF(enriched_df, ts_col = self.ts_col, partition_cols = self.partitionCols, freq = freq, func = func))
 

--- a/python/tempo/utils.py
+++ b/python/tempo/utils.py
@@ -1,3 +1,4 @@
+from typing import List
 import logging
 import os
 import warnings
@@ -6,7 +7,7 @@ from IPython.core.display import HTML
 from IPython.display import display as ipydisplay
 from pandas import DataFrame as pandasDataFrame
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.functions import expr
+from pyspark.sql.functions import expr, max, min, sum
 from tempo.resample import checkAllowableFreq, freq_dict
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,13 @@ DB_HOME env variable has been chosen and that's because this variable is a speci
 This constant is to ensure the correct behaviour of the show and display methods are called based on the platform 
 where the code is running from. 
 """
+
+
+class UpsampleWarning(Warning):
+    """
+    This class is a warning that is raised when the interpolate or resample with fill methods are called.
+    """
+    pass
 
 
 def __is_capable_of_html_rendering():
@@ -36,34 +44,55 @@ def __is_capable_of_html_rendering():
     except NameError:
         return False
 
-class UpsampleWarning(Warning):
-    pass
 
-def calculate_time_horizon(df: DataFrame, ts_col: str, freq: str):
+def calculate_time_horizon(
+    df: DataFrame, ts_col: str, freq: str, partition_cols: List[str]
+):
     # Convert Frequency using resample dictionary
     parsed_freq = checkAllowableFreq(freq)
     freq = f"{parsed_freq[0]} {freq_dict[parsed_freq[1]]}"
 
-    # Get max, min, and interval in epoch milliseconds
-    min_epoch, max_epoch = df.select(
-        expr(f"unix_millis(min({ts_col}))"), expr(f"unix_millis(max({ts_col}))")
+    # Get max and min timestamp per partition
+    partitioned_df: DataFrame = df.groupBy(*partition_cols).agg(
+        max(ts_col).alias("max_ts"),
+        min(ts_col).alias("min_ts"),
+    )
+
+    # Generate upscale metrics
+    normalized_time_df: DataFrame = (
+        partitioned_df.withColumn("min_epoch_ms", expr("unix_millis(min_ts)"))
+        .withColumn("max_epoch_ms", expr("unix_millis(max_ts)"))
+        .withColumn(
+            "interval_ms",
+            expr(
+                f"unix_millis(cast('1970-01-01 00:00:00.000+0000' as TIMESTAMP) + INTERVAL {freq})"
+            ),
+        )
+        .withColumn(
+            "rounded_min_epoch", expr("min_epoch_ms - (min_epoch_ms % interval_ms)")
+        )
+        .withColumn(
+            "rounded_max_epoch", expr("max_epoch_ms - (max_epoch_ms % interval_ms)")
+        )
+        .withColumn("diff_ms", expr("rounded_max_epoch - rounded_min_epoch"))
+        .withColumn("num_values", expr("(diff_ms/interval_ms) +1"))
+    )
+
+    min_ts, max_ts, max_value_partition, total_values = normalized_time_df.select(
+        min("min_ts"), max("max_ts"), max("num_values"), sum("num_values")
     ).first()
 
-    interval_ms = df.select(
-        expr(
-            f"unix_millis(cast('1970-01-01 00:00:00.000+0000' as TIMESTAMP) + INTERVAL {freq})"
-        )
-    ).first()[0]
-
-    # Round down to the nearest interval frequency
-    rounded_min_epoch = min_epoch - (min_epoch % interval_ms)
-    rounded_max_epoch = max_epoch - (max_epoch % interval_ms)
-
-    diff_ms = rounded_max_epoch - rounded_min_epoch
-    num_values = (diff_ms / interval_ms) + 1
-    warnings.simplefilter('always', UpsampleWarning)
+    warnings.simplefilter("always", UpsampleWarning)
     warnings.warn(
-        f"Upsample Warning: The resulting dataframe will contain {num_values} values.", UpsampleWarning
+        f"""
+            Upsample Metrics Warning: 
+                Earliest Timestamp: {min_ts}
+                Latest Timestamp: {max_ts}
+                No. of Unique Partitions: {normalized_time_df.count()}
+                Max No. Values in Single a Partition: {max_value_partition}
+                Total No. Values Across All Partitions: {total_values}
+        """,
+        UpsampleWarning,
     )
 
 

--- a/python/tempo/utils.py
+++ b/python/tempo/utils.py
@@ -7,7 +7,7 @@ from IPython.core.display import HTML
 from IPython.display import display as ipydisplay
 from pandas import DataFrame as pandasDataFrame
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.functions import expr, max, min, sum, avg, percentile_approx
+from pyspark.sql.functions import expr, max, min, sum, percentile_approx
 from tempo.resample import checkAllowableFreq, freq_dict
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ where the code is running from.
 """
 
 
-class UpsampleWarning(Warning):
+class ResampleWarning(Warning):
     """
     This class is a warning that is raised when the interpolate or resample with fill methods are called.
     """
@@ -99,21 +99,21 @@ def calculate_time_horizon(
         sum("num_values"),
     ).first()
 
-    warnings.simplefilter("always", UpsampleWarning)
+    warnings.simplefilter("always", ResampleWarning)
     warnings.warn(
         f"""
-            Upsample Metrics Warning: 
+            Resample Metrics Warning: 
                 Earliest Timestamp: {min_ts}
                 Latest Timestamp: {max_ts}
                 No. of Unique Partitions: {normalized_time_df.count()}
-                Min No. Values in Single a Partition: {min_value_partition}
-                Max No. Values in Single a Partition: {max_value_partition}
-                P25 No. Values in Single a Partition: {p25_value_partition}
-                P50 No. Values in Single a Partition: {p50_value_partition}
-                P75 No. Values in Single a Partition: {p75_value_partition}
-                Total No. Values Across All Partitions: {total_values}
+                Resampled Min No. Values in Single a Partition: {min_value_partition}
+                Resampled Max No. Values in Single a Partition: {max_value_partition}
+                Resampled P25 No. Values in Single a Partition: {p25_value_partition}
+                Resampled P50 No. Values in Single a Partition: {p50_value_partition}
+                Resampled P75 No. Values in Single a Partition: {p75_value_partition}
+                Resampled Total No. Values Across All Partitions: {total_values}
         """,
-        UpsampleWarning,
+        ResampleWarning,
     )
 
 

--- a/python/tempo/utils.py
+++ b/python/tempo/utils.py
@@ -36,6 +36,8 @@ def __is_capable_of_html_rendering():
     except NameError:
         return False
 
+class UpsampleWarning(Warning):
+    pass
 
 def calculate_time_horizon(df: DataFrame, ts_col: str, freq: str):
     # Convert Frequency using resample dictionary
@@ -59,9 +61,9 @@ def calculate_time_horizon(df: DataFrame, ts_col: str, freq: str):
 
     diff_ms = rounded_max_epoch - rounded_min_epoch
     num_values = (diff_ms / interval_ms) + 1
-
+    warnings.simplefilter('always', UpsampleWarning)
     warnings.warn(
-        f"Interpolation/Resample Warning: The resulting dataframe will contain {num_values} values."
+        f"Upsample Warning: The resulting dataframe will contain {num_values} values.", UpsampleWarning
     )
 
 

--- a/python/tempo/utils.py
+++ b/python/tempo/utils.py
@@ -4,12 +4,9 @@ import warnings
 from IPython import get_ipython
 from IPython.core.display import HTML
 from IPython.display import display as ipydisplay
-from black import diff
-from numpy import double
 from pandas import DataFrame as pandasDataFrame
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import expr
-from pyspark.sql import SparkSession
 from tempo.resample import checkAllowableFreq, freq_dict
 
 logger = logging.getLogger(__name__)

--- a/python/tests/tsdf_tests.py
+++ b/python/tests/tsdf_tests.py
@@ -619,17 +619,6 @@ class RangeStatsTest(SparkTest):
         self.assertDataFramesEqual(featured_df, dfExpected)
 
 
-class UtilsTest(SparkTest):
-
-    def test_display(self):
-        """Test of the display utility"""
-        if PLATFORM == 'DATABRICKS':
-            self.assertEqual(id(display),id(display_improvised))
-        elif ENV_BOOLEAN:
-            self.assertEqual(id(display),id(display_html_improvised))
-        else:
-            self.assertEqual(id(display),id(display_unavailable))
-
 class ResampleTest(SparkTest):
 
     def test_resample(self):

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -58,7 +58,7 @@ class UtilsTest(UtilsTest):
                 self.simple_input_tsdf.df, self.simple_input_tsdf.ts_col, "30 seconds"
             )
             assert (
-                "Interpolation/Resample Warning: The resulting dataframe will contain 12.0 values."
+                "Upsample Warning: The resulting dataframe will contain 12.0 values."
                 == str(w[-1].message)
             )
 

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -1,0 +1,81 @@
+from pyspark.sql.types import *
+from tests.tsdf_tests import SparkTest
+from tempo.utils import calculate_time_horizon
+from chispa.dataframe_comparer import *
+from tempo.tsdf import TSDF
+from tempo.interpol import Interpolation
+from tempo.utils import *
+import unittest
+
+
+class UtilsTest(SparkTest):
+    def buildTestingDataFrame(self):
+        schema = StructType(
+            [
+                StructField("partition_a", StringType()),
+                StructField("partition_b", StringType()),
+                StructField("event_ts", StringType()),
+                StructField("value_a", FloatType()),
+                StructField("value_b", FloatType()),
+            ]
+        )
+
+        self.expected_schema = StructType(
+            [
+                StructField("partition_a", StringType()),
+                StructField("partition_b", StringType()),
+                StructField("event_ts", StringType(), False),
+                StructField("value_a", DoubleType()),
+                StructField("value_b", DoubleType()),
+                StructField("is_ts_interpolated", BooleanType(), False),
+                StructField("is_interpolated_value_a", BooleanType(), False),
+                StructField("is_interpolated_value_b", BooleanType(), False),
+            ]
+        )
+
+        simple_data = [
+            ["A", "A-1", "2020-01-01 00:00:10", 0.0, None],
+            ["A", "A-1", "2020-01-01 00:01:10", 2.0, 2.0],
+            ["A", "A-1", "2020-01-01 00:01:32", None, None],
+            ["A", "A-1", "2020-01-01 00:02:03", None, None],
+            ["A", "A-1", "2020-01-01 00:03:32", None, 7.0],
+            ["A", "A-1", "2020-01-01 00:04:12", 8.0, 8.0],
+            ["A", "A-1", "2020-01-01 00:05:31", 11.0, None],
+        ]
+
+        # construct dataframes
+        self.simple_input_df = self.buildTestDF(schema, simple_data)
+
+        self.simple_input_tsdf = TSDF(
+            self.simple_input_df,
+            partition_cols=["partition_a", "partition_b"],
+            ts_col="event_ts",
+        )
+
+
+class UtilsTest(UtilsTest):
+    def test_display(self):
+        """Test of the display utility"""
+        if PLATFORM == "DATABRICKS":
+            self.assertEqual(id(display), id(display_improvised))
+        elif ENV_BOOLEAN:
+            self.assertEqual(id(display), id(display_html_improvised))
+        else:
+            self.assertEqual(id(display), id(display_unavailable))
+
+    def test_calculate_time_horizon(self):
+        """Test calculate time horizon warning and number of expected output rows"""
+        self.buildTestingDataFrame()
+        with warnings.catch_warnings(record=True) as w:
+            calculate_time_horizon(
+                self.simple_input_tsdf.df, self.simple_input_tsdf.ts_col, "30 seconds"
+            )
+            assert (
+                "Time Horizon Warning: The resulting dataframe will contain 12.0 values."
+                == str(w[-1].message)
+            )
+
+
+## MAIN
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -71,7 +71,7 @@ class UtilsTest(UtilsTest):
                 self.simple_input_tsdf.df, self.simple_input_tsdf.ts_col, "30 seconds"
             )
             assert (
-                "Time Horizon Warning: The resulting dataframe will contain 12.0 values."
+                "Interpolation/Resample Warning: The resulting dataframe will contain 12.0 values."
                 == str(w[-1].message)
             )
 

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -72,16 +72,16 @@ class UtilsTest(UtilsTest):
                 ["partition_a", "partition_b"],
             )
             warning_message = """
-            Upsample Metrics Warning: 
+            Resample Metrics Warning: 
                 Earliest Timestamp: 2020-01-01 00:00:10
                 Latest Timestamp: 2020-01-01 00:05:31
                 No. of Unique Partitions: 3
-                Min No. Values in Single a Partition: 7.0
-                Max No. Values in Single a Partition: 12.0
-                P25 No. Values in Single a Partition: 7.0
-                P50 No. Values in Single a Partition: 12.0
-                P75 No. Values in Single a Partition: 12.0
-                Total No. Values Across All Partitions: 31.0
+                Resampled Min No. Values in Single a Partition: 7.0
+                Resampled Max No. Values in Single a Partition: 12.0
+                Resampled P25 No. Values in Single a Partition: 7.0
+                Resampled P50 No. Values in Single a Partition: 12.0
+                Resampled P75 No. Values in Single a Partition: 12.0
+                Resampled Total No. Values Across All Partitions: 31.0
             """
             assert warning_message.strip() == str(w[-1].message).strip()
 

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -28,6 +28,17 @@ class UtilsTest(SparkTest):
             ["A", "A-1", "2020-01-01 00:03:32", None, 7.0],
             ["A", "A-1", "2020-01-01 00:04:12", 8.0, 8.0],
             ["A", "A-1", "2020-01-01 00:05:31", 11.0, None],
+            ["A", "A-2", "2020-01-01 00:00:10", 0.0, None],
+            ["A", "A-2", "2020-01-01 00:01:10", 2.0, 2.0],
+            ["A", "A-2", "2020-01-01 00:01:32", None, None],
+            ["A", "A-2", "2020-01-01 00:02:03", None, None],
+            ["A", "A-2", "2020-01-01 00:04:12", 8.0, 8.0],
+            ["A", "A-2", "2020-01-01 00:05:31", 11.0, None],
+            ["B", "A-2", "2020-01-01 00:01:10", 2.0, 2.0],
+            ["B", "A-2", "2020-01-01 00:01:32", None, None],
+            ["B", "A-2", "2020-01-01 00:02:03", None, None],
+            ["B", "A-2", "2020-01-01 00:03:32", None, 7.0],
+            ["B", "A-2", "2020-01-01 00:04:12", 8.0, 8.0],
         ]
 
         # construct dataframes
@@ -55,12 +66,16 @@ class UtilsTest(UtilsTest):
         self.buildTestingDataFrame()
         with warnings.catch_warnings(record=True) as w:
             calculate_time_horizon(
-                self.simple_input_tsdf.df, self.simple_input_tsdf.ts_col, "30 seconds"
+                self.simple_input_tsdf.df,
+                self.simple_input_tsdf.ts_col,
+                "30 seconds",
+                ["partition_a", "partition_b"],
             )
-            assert (
-                "Upsample Warning: The resulting dataframe will contain 12.0 values."
-                == str(w[-1].message)
-            )
+            print(w[-1].message)
+            # assert (
+            #     "Upsample Warning: The resulting dataframe will contain 12.0 values."
+            #     == str(w[-1].message)
+            # )
 
 
 ## MAIN

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -20,19 +20,6 @@ class UtilsTest(SparkTest):
             ]
         )
 
-        self.expected_schema = StructType(
-            [
-                StructField("partition_a", StringType()),
-                StructField("partition_b", StringType()),
-                StructField("event_ts", StringType(), False),
-                StructField("value_a", DoubleType()),
-                StructField("value_b", DoubleType()),
-                StructField("is_ts_interpolated", BooleanType(), False),
-                StructField("is_interpolated_value_a", BooleanType(), False),
-                StructField("is_interpolated_value_b", BooleanType(), False),
-            ]
-        )
-
         simple_data = [
             ["A", "A-1", "2020-01-01 00:00:10", 0.0, None],
             ["A", "A-1", "2020-01-01 00:01:10", 2.0, 2.0],

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -71,23 +71,19 @@ class UtilsTest(UtilsTest):
                 "30 seconds",
                 ["partition_a", "partition_b"],
             )
-            print(w[-1].message)
-
-            assert (
-                f"""
-                    Upsample Metrics Warning: 
-                        Earliest Timestamp: 2020-01-01 00:00:10
-                        Latest Timestamp: 2020-01-01 00:05:31
-                        No. of Unique Partitions: 3
-                        Min No. Values in Single a Partition: 7.0
-                        Max No. Values in Single a Partition: 12.0
-                        P25 No. Values in Single a Partition: 7.0
-                        P50 No. Values in Single a Partition: 12.0
-                        P75 No. Values in Single a Partition: 12.0
-                        Total No. Values Across All Partitions: 31.0
-                """
-                == str(w[-1].message)
-            )
+            warning_message = """
+            Upsample Metrics Warning: 
+                Earliest Timestamp: 2020-01-01 00:00:10
+                Latest Timestamp: 2020-01-01 00:05:31
+                No. of Unique Partitions: 3
+                Min No. Values in Single a Partition: 7.0
+                Max No. Values in Single a Partition: 12.0
+                P25 No. Values in Single a Partition: 7.0
+                P50 No. Values in Single a Partition: 12.0
+                P75 No. Values in Single a Partition: 12.0
+                Total No. Values Across All Partitions: 31.0
+            """
+            assert warning_message.strip() == str(w[-1].message).strip()
 
 
 ## MAIN

--- a/python/tests/utils_tests.py
+++ b/python/tests/utils_tests.py
@@ -72,10 +72,22 @@ class UtilsTest(UtilsTest):
                 ["partition_a", "partition_b"],
             )
             print(w[-1].message)
-            # assert (
-            #     "Upsample Warning: The resulting dataframe will contain 12.0 values."
-            #     == str(w[-1].message)
-            # )
+
+            assert (
+                f"""
+                    Upsample Metrics Warning: 
+                        Earliest Timestamp: 2020-01-01 00:00:10
+                        Latest Timestamp: 2020-01-01 00:05:31
+                        No. of Unique Partitions: 3
+                        Min No. Values in Single a Partition: 7.0
+                        Max No. Values in Single a Partition: 12.0
+                        P25 No. Values in Single a Partition: 7.0
+                        P50 No. Values in Single a Partition: 12.0
+                        P75 No. Values in Single a Partition: 12.0
+                        Total No. Values Across All Partitions: 31.0
+                """
+                == str(w[-1].message)
+            )
 
 
 ## MAIN


### PR DESCRIPTION
### What

Add warning when using `interpolate` or `resample` (where fill is True) and also provide an estimate as to how many data points are going to be present into the resulting output DataFrame along with any potential skew along specific partitions. 

This warning will always be triggered as a first stage; therefore, users will still have the option to choose whether they want to cancel the operation or not after the anticipated upscale warning metrics have been computed. 

The following is a screen shot of what this would looks like within a Databricks notebook:

![Screen Shot 2022-05-13 at 7 33 32 PM](https://user-images.githubusercontent.com/75445106/168405904-c1aea87d-4f25-4f77-9ce6-1c9c35f76183.png)
_Screenshot text is a bit out of date, but still represents what it should look like for the user._

This will add a bit of additional overhead to the aforementioned operations as a result of having to calculating the time boundaries e.g. MAX and MIN for the input time series data frame.

Also moved UtilsTest into its own separate file.



### Why
For users to be alerted if the time horizon + frequency selected will produce an unexpectedly large number of new events.

### Reference Issue
https://github.com/databrickslabs/tempo/issues/170

