### PR TITLE
Need to mark source directory as "safe" for git to perform actions during docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - 'v*' # only release a versioned tag, such as v.X.Y.Z
-    branches: ['*']
 
 jobs:
   build-docs:
@@ -21,7 +20,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-          set-safe-directory: $GITHUB_WORKSPACE
       - name: Copy Requirements
         uses: canastro/copy-file-action@master
         with:
@@ -36,9 +34,9 @@ jobs:
         with:
           name: html-docs
           path: docs/_build/html/
-#      - name: Deploy 🚀
-#        uses: peaceiris/actions-gh-pages@v3
-#        if: $${{ github.ref }} == 'refs/heads/master'
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_dir: docs/_build/html
+      - name: Deploy 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        if: $${{ github.ref }} == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+          set-safe-directory: $GITHUB_WORKSPACE
       - name: Copy Requirements
         uses: canastro/copy-file-action@master
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build HTML
         uses: ammaraskar/sphinx-action@0.4
         with:
-          pre-build-command: "apt-get update -y && apt-get install -y git"
+          pre-build-command: "apt-get update -y && apt-get install -y git && git config --global --add safe.directory /github/workspace"
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           name: html-docs
           path: docs/_build/html/
-      - name: Deploy 🚀
-        uses: peaceiris/actions-gh-pages@v3
-        if: $${{ github.ref }} == 'refs/heads/master'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build/html
+#      - name: Deploy 🚀
+#        uses: peaceiris/actions-gh-pages@v3
+#        if: $${{ github.ref }} == 'refs/heads/master'
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          publish_dir: docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*' # only release a versioned tag, such as v.X.Y.Z
+    branches: ['*']
 
 jobs:
   build-docs:


### PR DESCRIPTION
We have a system call to git during the docs build that fetches the current release version from git tags. This started to fail because the directory where the code was cloned was not marked as "safe". This should fix that issue.