### PR TITLE
Fix list-to-set syntax

### DIFF
--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -761,8 +761,8 @@ class TSDF:
             if (left_bytes < bytes_threshold) or (right_bytes < bytes_threshold):
                 spark.conf.set("spark.databricks.optimizer.rangeJoin.binSize", 60)
                 partition_cols = right_tsdf.partitionCols
-                left_cols = list(set(left_df.columns) - set(self.partitionCols))
-                right_cols = list(set(right_df.columns) - set(right_tsdf.partitionCols))
+                left_cols = list({left_df.columns} - {self.partitionCols})
+                right_cols = list({right_df.columns} - {right_tsdf.partitionCols})
 
                 left_prefix = (
                     ""

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -761,8 +761,8 @@ class TSDF:
             if (left_bytes < bytes_threshold) or (right_bytes < bytes_threshold):
                 spark.conf.set("spark.databricks.optimizer.rangeJoin.binSize", 60)
                 partition_cols = right_tsdf.partitionCols
-                left_cols = list({left_df.columns} - {self.partitionCols})
-                right_cols = list({right_df.columns} - {right_tsdf.partitionCols})
+                left_cols = list(set(left_df.columns) - set(self.partitionCols))
+                right_cols = list(set(right_df.columns) - set(right_tsdf.partitionCols))
 
                 left_prefix = (
                     ""

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -761,7 +761,9 @@ class TSDF:
             if (left_bytes < bytes_threshold) or (right_bytes < bytes_threshold):
                 spark.conf.set("spark.databricks.optimizer.rangeJoin.binSize", 60)
                 partition_cols = right_tsdf.partitionCols
-                left_cols = list(set(left_df.columns).difference(set(self.partitionCols)))
+                left_cols = list(
+                    set(left_df.columns).difference(set(self.partitionCols))
+                )
                 right_cols = list(
                     set(right_df.columns).difference(set(right_tsdf.partitionCols))
                 )
@@ -806,7 +808,9 @@ class TSDF:
                     )
                     .drop("lead_" + right_tsdf.ts_col)
                 )
-                return TSDF(res, partition_cols=self.partitionCols, ts_col=new_left_ts_col)
+                return TSDF(
+                    res, partition_cols=self.partitionCols, ts_col=new_left_ts_col
+                )
 
         # end of block checking to see if standard Spark SQL join will work
 

--- a/python/tempo/tsdf.py
+++ b/python/tempo/tsdf.py
@@ -761,12 +761,8 @@ class TSDF:
             if (left_bytes < bytes_threshold) or (right_bytes < bytes_threshold):
                 spark.conf.set("spark.databricks.optimizer.rangeJoin.binSize", 60)
                 partition_cols = right_tsdf.partitionCols
-                left_cols = list(
-                    set(left_df.columns).difference(set(self.partitionCols))
-                )
-                right_cols = list(
-                    set(right_df.columns).difference(set(right_tsdf.partitionCols))
-                )
+                left_cols = list({left_df.columns} - {self.partitionCols})
+                right_cols = list({right_df.columns} - {right_tsdf.partitionCols})
 
                 left_prefix = (
                     ""


### PR DESCRIPTION
Turns out we introduced a bug in #337.

You can't convert a list to a set with the curly-brace set literal syntax.
This is correct for defining a set literal: `{1, 2, 3, 4}`
But this is not correct for converting a list to a set: `{[1, 2, 3, 4]}`
Instead you must explicitly use the `set` function: `set([1, 2, 3, 4])`