### PR TITLE
[tox] update env to avoid exit 1 error

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -34,7 +34,6 @@ deps =
 commands =
     coverage --version
     coverage run -m unittest discover -s tests -p '*_tests.py'
-    coverage report -m --data-file .coverage.{envname}
 
 [testenv:format]
 description = run formatters


### PR DESCRIPTION
Removing a line that looks for coverage file based on tox env. Coverage runs tests in parallel so added a guid to the end of the env name making it undiscoverable.

After running tox -e <env> to run tests a user can see the coverage report by running tox -e coverage-report.