### PR TITLE
[chore] Fix codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,4 +71,7 @@ jobs:
         coverage combine
         coverage xml
     - name: Publish test coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
+      with:
+          fail_ci_if_error: true
+          files: ./python/coverage.xml


### PR DESCRIPTION
update GH workflow to publish xml coverage file to codecov so viewabl…e on the website