### PR TITLE
Remove `Analyze` job from test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,45 +29,6 @@ jobs:
     - name: Type check
       working-directory: ./python
       run: tox -e type-check
-  
-  analyze:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-    #- run: |
-    #   make bootstrap
-    #   make release
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
 
   test:
     needs: lint-and-check


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This removes the Analyze job which called CodeQL; The action is broken due to network rule changes on the GH org side

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added a new Class method
- [ ] modified existing Class method: `...`
- [ ] added a new function
- [ ] modified existing function: `...`
- [ ] added a new test
- [ ] modified existing test: `...`
- [ ] added a new example
- [ ] modified existing example: `...`
- [ ] added a new utility
- [ ] modified existing utility: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [x] verified on staging environment (screenshot attached)
<img width="841" alt="image" src="https://github.com/user-attachments/assets/7d4fee62-589f-4741-9092-de8a736ad9f5" />
