### PR TITLE
Fix Makefile lint target empty variable expansion causing hatch JSON parsing error

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -200,7 +200,7 @@ test-all: check-java
 .PHONY: lint
 lint:
 	@echo "Running linters..."
-	hatch run lint:runLint $()
+	hatch run lint:runLint $(LINT_PARAMS)
 
 # Format code with Black
 .PHONY: format


### PR DESCRIPTION
The lint target was using empty parentheses `$()` instead of `$(LINT_PARAMS)`, causing `hatch` to fail with a JSON parsing error when LINT_PARAMS was passed from the GitHub Actions workflow.

## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added a new Class method
- [ ] modified existing Class method: `...`
- [ ] added a new function
- [ ] modified existing function: `...`
- [ ] added a new test
- [ ] modified existing test: `...`
- [ ] added a new example
- [ ] modified existing example: `...`
- [ ] added a new utility
- [ ] modified existing utility: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)