### PR TITLE
Fix CI lint error by removing redundant LINT_PARAMS from Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install hatch 
     - name: Lint check
       working-directory: ./python
-      run: make lint LINT_PARAMS="-- --check --diff"
+      run: make lint
     - name: Type check
       working-directory: ./python
       run: make type-check

--- a/python/Makefile
+++ b/python/Makefile
@@ -200,7 +200,7 @@ test-all: check-java
 .PHONY: lint
 lint:
 	@echo "Running linters..."
-	hatch run lint:runLint $(LINT_PARAMS)
+	hatch run lint:runLint
 
 # Format code with Black
 .PHONY: format

--- a/python/Makefile
+++ b/python/Makefile
@@ -200,7 +200,7 @@ test-all: check-java
 .PHONY: lint
 lint:
 	@echo "Running linters..."
-	hatch run lint:runLint $()
+	hatch run lint:runLint $(LINT_PARAMS)
 
 # Format code with Black
 .PHONY: format


### PR DESCRIPTION
Changes

  Fixed CI lint error that was causing TypeError: the JSON object must be str, bytes or bytearray, not Sentinel by removing redundant parameter passing in Makefile and GitHub workflow.

  Root Cause

  The error occurred because the GitHub workflow was passing `LINT_PARAMS="-- --check --diff"` to the Makefile's lint target, which then passed these parameters to `hatch run lint:runLint`. Hatch's argument parser misinterpreted the `--` separator and subsequent flags, attempting to parse them as its own options, leading to a JSON filter parsing error.

  Proposed Fix

  - Removed `$(LINT_PARAMS)` from the Makefile's lint target
  - Updated GitHub workflow to call make lint without additional parameters
  - The `--check` and `--diff` flags are already defined in pyproject.toml line 139, making the parameter passing both redundant and problematic

  Linked issues

  Resolves #..

  Functionality

  - added relevant user documentation
  - added a new Class method
  - modified existing Class method: ...
  - added a new function
  - modified existing function: ...
  - added a new test
  - modified existing test: ...
  - added a new example
  - modified existing example: ...
  - added a new utility
  - modified existing utility: Makefile lint target and GitHub workflow

  Tests

  - manually tested locally

  Manually tested both make lint and make type-check commands locally - both execute successfully without errors.