### PR TITLE
Fix CI failures due to hatch/click incompatibility and streamline developer setup

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -28,10 +28,9 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install hatch
+      - name: Setup development tools
+        working-directory: ./python
+        run: make setup
 
       - name: Build docs
         working-directory: ./python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,9 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install hatch
+      - name: Setup development tools
+        working-directory: ./python
+        run: make setup
 
       - name: Build dist
         working-directory: ./python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup development tools
       working-directory: ./python
       run: make setup
-    - name: Execute hatch envs
+    - name: Run tests
       working-directory: ./python
       run: make test coverage-report DBR=${{ matrix.config.dbr }}
     - name: Publish test coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install hatch 
+    - name: Setup development tools
+      working-directory: ./python
+      run: make setup 
     - name: Lint check
       working-directory: ./python
       run: make lint
@@ -56,11 +55,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config.py }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install semver
-        python -m pip install hatch
+    - name: Setup development tools
+      working-directory: ./python
+      run: make setup
     - name: Execute hatch envs
       working-directory: ./python
       run: make test coverage-report DBR=${{ matrix.config.dbr }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,10 @@ jobs:
         python-version: '3.10'
     - name: Setup development tools
       working-directory: ./python
-      run: make setup 
-    - name: Lint check
+      run: make setup
+    - name: Run code quality checks (format, lint, type-check)
       working-directory: ./python
-      run: make lint
-    - name: Type check
-      working-directory: ./python
-      run: make type-check
+      run: make quality
 
   test:
     needs: lint-and-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install hatch 
     - name: Lint check
       working-directory: ./python
-      run: make lint LINT_PARAMS="-- --check --diff"
+      run: make lint
     - name: Type check
       working-directory: ./python
       run: make type-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,25 +89,41 @@ make test-all       # Test all DBR versions
 
 ## Code Quality
 
-### Run linters and formatters
+### Run individual quality checks
 ```bash
-make lint           # Run linters
 make format         # Format code with Black
+make lint           # Run linters
 make type-check     # Run type checking
 ```
 
-### Run all checks at once
+### Run all quality checks at once
 ```bash
-make all-local      # Run all local tests and checks
+make quality        # Run format + lint + type-check sequentially
 ```
 
 ## Building
 
+### Build artifacts
 ```bash
-make build-dist     # Build distribution packages
-make build-docs     # Build documentation
-make coverage-report # Generate test coverage report
+make build          # Build distribution and documentation
+make build-dist     # Build distribution packages only
+make build-docs     # Build documentation only
 ```
+
+### Generate coverage report
+```bash
+make coverage-report # Generate test coverage report (requires tests to be run first)
+```
+
+## Complete CI Pipeline
+
+### Run the complete CI pipeline locally
+```bash
+make ci             # Run quality + test-all + build + coverage
+make all            # Alias for 'make ci'
+```
+
+This runs the same checks as the GitHub Actions CI pipeline.
 
 ## Code Style & Standards
 
@@ -117,13 +133,14 @@ to check for effective code style, type-checking and common bad practices.
 
 To test your code against these standards, run:
 ```bash
-make lint
-make type-check
+make quality        # Run all quality checks (format + lint + type-check)
 ```
 
-To have `black` automatically format your code, run:
+Or run them individually:
 ```bash
-make format
+make format         # Format code with Black
+make lint           # Run linters
+make type-check     # Run type checking
 ```
 
 In addition, we apply some project-specific standards:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,57 @@
-# Setup instructions
+# Contributing to Tempo
 
-We use `tox` and `pyenv` to manage developing and testing `tempo` across multiple Python versions and PySpark versions.
-`tox` is a testing tool that helps you automate and standardize testing in Python across multiple environments.
-`pyenv` allows you to manage multiple versions of Python on your computer and easily switch between them.
+## Quick Start
 
-## Pyenv setup
+```bash
+cd tempo/python
+make init  # Complete setup for new developers
+```
 
-Since `tox` supports creating virtual environments using multiple Python versions, it is recommended to use `pyenv` to manage Python versions on your computer.
-`pyenv` does not install via `pip` on all platforms, so see the [pyenv documentation](https://github.com/pyenv/pyenv#installation) for installation instructions. 
+This will set up your complete development environment.
+
+## Development Setup
+
+### Prerequisites
+- Python 3.9, 3.10, or 3.11
+- pip
+- make
+
+### Setup Instructions
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/databrickslabs/tempo.git
+   cd tempo/python
+   ```
+
+2. **Initialize development environment**
+   ```bash
+   make init  # Complete setup (recommended)
+   ```
+
+   Or if you prefer manual steps:
+   ```bash
+   make setup         # Install development tools
+   make check-env     # Verify environment
+   make venv          # Create virtual environment for default DBR
+   ```
+
+3. **Check status**
+   ```bash
+   make status        # Quick status check
+   make doctor        # Comprehensive health check
+   ```
+
+## Python Version Management
+
+Since we test across multiple Python versions, it is recommended to use `pyenv` to manage Python versions on your computer.
+
+### Pyenv Setup
+
+`pyenv` does not install via `pip` on all platforms, so see the [pyenv documentation](https://github.com/pyenv/pyenv#installation) for installation instructions.
 Be sure to carefully follow the instructions to configure your shell environment to use `pyenv`, otherwise subsequent commands will not work as intended.
 
-Use `pyenv` to install the following Python versions for testing.
+Use `pyenv` to install the following Python versions for testing:
 ```bash
 pyenv install 3.9 3.10 3.11
 ```
@@ -26,73 +67,68 @@ Within the `tempo/python` folder, run the below command to create a `.python-ver
 pyenv local 3.9 3.10 3.11
 ```
 
-This allows `tox` to create virtual environments using any of the Python versions listed in the `.python-version` file.
+## Running Tests
 
-## Tox setup
-
-Install tox:
+### Test a specific DBR version
 ```bash
-pip install -U tox
+make test           # Test with default DBR version (154)
+make test DBR=143   # Test with specific DBR version
 ```
 
-A brief description of each managed `tox` environment can be found by running `tox list` or in the `tox.ini` file.
-
-## Create a development environment
-Each development environment is roughly associated with a DBR LTS version. A list of base environments can be found in your `tox.ini` file, but the number specified below is only the version number.
-Run the following command in your terminal to create a virtual environment (you can replace "your_dbr_number" with something like 154, 143, etc.):
+### Test all DBR versions
 ```bash
-make venv DBR={your_dbr_number}
+make test-all       # Test all DBR versions
 ```
 
+### DBR Versions Supported
+- **DBR 154** - Python 3.11 (default)
+- **DBR 143** - Python 3.10
+- **DBR 133** - Python 3.10
+- **DBR 122** - Python 3.9
+- **DBR 113** - Python 3.9
 
-## Environments we test
-Use the following to run tests for a given environment. 
+## Code Quality
+
+### Run linters and formatters
 ```bash
-make test DBR={your_dbr_number}
+make lint           # Run linters
+make format         # Format code with Black
+make type-check     # Run type checking
 ```
 
-If you would like to run tests for all environments, use
+### Run all checks at once
 ```bash
-make test-all
+make all-local      # Run all local tests and checks
 ```
 
-### Run additional checks locally
-`tox` has special environments for additional checks that must be performed as part of the PR process. These include formatting, linting, type checking, etc.
-These environments are also defined in the `tox.ini`file and skip installing dependencies listed in the `requirements.txt` file and building the distribution when those are not required . They can be specified using the `-e` flag:
-* lint
-* type-check
-* build-dist
-* build-docs
-* coverage-report
+## Building
 
-To run an individual check, use
+```bash
+make build-dist     # Build distribution packages
+make build-docs     # Build documentation
+make coverage-report # Generate test coverage report
+```
+
+## Code Style & Standards
+
+The tempo project abides by [`black`](https://black.readthedocs.io/en/stable/index.html) formatting standards,
+as well as using [`flake8`](https://flake8.pycqa.org/en/latest/) and [`mypy`](https://mypy.readthedocs.io/en/stable/)
+to check for effective code style, type-checking and common bad practices.
+
+To test your code against these standards, run:
 ```bash
 make lint
 make type-check
-make {name_of_environment}
 ```
 
-To run all checks at once, run
+To have `black` automatically format your code, run:
 ```bash
-make all-local
-```
-# Code style & Standards
-
-The tempo project abides by [`black`](https://black.readthedocs.io/en/stable/index.html) formatting standards, 
-as well as using [`flake8`](https://flake8.pycqa.org/en/latest/) and [`mypy`](https://mypy.readthedocs.io/en/stable/) 
-to check for effective code style, type-checking and common bad practices.
-To test your code against these standards, run the following command:
-```bash
-tox -e lint, type-check
-```
-To have `black` automatically format your code, run the following command:
-```bash
-tox -e format
+make format
 ```
 
 In addition, we apply some project-specific standards:
 
-## Module imports
+### Module imports
 
 We organize import statements at the top of each module in the following order, each section being separated by a blank line:
 1. Standard Python library imports
@@ -102,6 +138,44 @@ We organize import statements at the top of each module in the following order, 
 
 Within each section, imports are sorted alphabetically. While it is acceptable to directly import classes and some functions that are
 going to be commonly used, for the sake of readability, it is generally preferred to import a package with an alias and then use the alias
-to reference the package's classes and functions. 
+to reference the package's classes and functions.
 
 When importing `pyspark.sql.functions`, we use the convention to alias this package as `sfn`, which is both distinctive and short.
+
+## Troubleshooting
+
+### Dependency Issues
+If you see errors during setup or when running commands:
+```bash
+make setup          # Reinstall development tools
+```
+
+### Python Version Issues
+If you need a specific Python version:
+```bash
+make setup-python-versions  # Install all required Python versions
+```
+
+### Clean Slate
+If things are broken:
+```bash
+make clean          # Remove all generated files
+make deep-clean     # Remove everything (venvs, caches, artifacts)
+make init           # Reinstall everything
+```
+
+### Known Issues
+See `python/.env.versions` for notes on current tool version constraints and tracking issues.
+
+## Version Management
+
+Tool versions are centrally managed in `python/.env.versions`:
+- Both local development and CI use these same versions
+- To update versions, modify `.env.versions` and run `make setup`
+
+## CI/CD
+
+GitHub Actions workflows automatically:
+- Source `.env.versions` for consistent tool versions
+- Run tests across all DBR versions
+- Enforce the same linting and type checking as local development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,6 @@ This will set up your complete development environment.
    Or if you prefer manual steps:
    ```bash
    make setup         # Install development tools
-   make check-env     # Verify environment
    make venv          # Create virtual environment for default DBR
    ```
 

--- a/python/.env.versions
+++ b/python/.env.versions
@@ -1,0 +1,15 @@
+# Version constraints for development tools
+# These versions are used in both CI and local development
+# Source this file or use in scripts to ensure consistency
+#
+# TRACKING ISSUES:
+# - Hatch + Click 8.3.0 compatibility: https://github.com/pypa/hatch/issues/2050
+# - Click 8.3.0 regression: https://github.com/pallets/click/issues/3065
+#
+# Once these issues are resolved, we can upgrade to latest hatch without the click constraint
+
+HATCH_VERSION="1.9.4"
+CLICK_CONSTRAINT="click<8.3.0"
+
+# Full pip install command
+HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION} '${CLICK_CONSTRAINT}'"

--- a/python/Makefile
+++ b/python/Makefile
@@ -200,7 +200,7 @@ test-all: check-java
 .PHONY: lint
 lint:
 	@echo "Running linters..."
-	hatch run lint:runLint $(LINT_PARAMS)
+	hatch run lint:runLint
 
 # Format code with Black
 .PHONY: format

--- a/python/Makefile
+++ b/python/Makefile
@@ -142,8 +142,8 @@ status:
 		echo "Java 8: not installed"; \
 	fi
 	@# Check virtual environments
-	@if [ -d ".venv" ]; then \
-		COUNT=$$(ls -1 .venv | wc -l | tr -d ' '); \
+	@if [ -d "${VENV_DIR}" ]; then \
+		COUNT=$$(ls -1 ${VENV_DIR} | wc -l | tr -d ' '); \
 		echo "Virtual environments: $${COUNT}"; \
 	else \
 		echo "Virtual environments: none (run 'make venv')"; \
@@ -174,8 +174,8 @@ doctor:
 	fi
 	@echo ""
 	@echo " Virtual Environments:"
-	@if [ -d ".venv" ]; then \
-		for env in .venv/*; do \
+	@if [ -d "${VENV_DIR}" ]; then \
+		for env in ${VENV_DIR}/*; do \
 			if [ -d "$$env" ]; then \
 				echo "   $$(basename $$env)"; \
 			fi; \
@@ -201,7 +201,7 @@ quality: format lint type-check
 .PHONY: deep-clean
 deep-clean: clean
 	@echo " Deep cleaning - removing all artifacts..."
-	@rm -rf .venv/
+	@rm -rf ${VENV_DIR}/
 	@rm -rf .tox/
 	@rm -rf __pycache__/
 	@rm -rf .pytest_cache/

--- a/python/Makefile
+++ b/python/Makefile
@@ -41,16 +41,29 @@ help:
 	@echo "  make check-env             Check Python and Java environment setup"
 	@echo "  make venv                  Create virtual environment for newest, supported DBR version"
 	@echo "  make venv DBR=<version>    Create virtual environment for a specific DBR version"
+	@echo ""
+	@echo "Testing:"
 	@echo "  make test                  Run tests for the newest, supported DBR version"
 	@echo "  make test DBR=<version>    Run tests for a specific DBR version"
 	@echo "  make test-all              Run tests for all supported DBR versions"
-	@echo "  make coverage-report       Generate test coverage report"
+	@echo "  make coverage-report       Generate test coverage report (requires test run first)"
+	@echo ""
+	@echo "Code Quality:"
+	@echo "  make quality               Run all code quality checks (format + lint + type-check)"
 	@echo "  make lint                  Run linters"
 	@echo "  make format                Format code with Black"
 	@echo "  make type-check            Run type checks"
-	@echo "  make build-dist            Build distribution"
-	@echo "  make build-docs            Build documentation"
-	@echo "  make all-local             Run all local tests and checks"
+	@echo ""
+	@echo "Build:"
+	@echo "  make build                 Build distribution and documentation"
+	@echo "  make build-dist            Build distribution only"
+	@echo "  make build-docs            Build documentation only"
+	@echo ""
+	@echo "Complete CI:"
+	@echo "  make ci                    Run complete CI pipeline (quality + test-all + build + coverage)"
+	@echo "  make all                   Alias for 'make ci'"
+	@echo ""
+	@echo "Cleanup:"
 	@echo "  make clean                 Remove all generated files"
 	@echo "  make deep-clean            Remove everything (venvs, caches, artifacts)"
 	@echo ""
@@ -178,9 +191,10 @@ doctor:
 		echo "    Issues detected - run 'make init' to fix"; \
 	fi
 
-# Run all code quality checks (alias for lint + type-check)
+# Run all code quality checks (format + lint + type-check)
 .PHONY: quality
-quality: lint type-check
+quality: format lint type-check
+	@echo "✅ All quality checks passed!"
 
 
 # Deep clean - remove everything including venvs
@@ -373,10 +387,15 @@ test: check-env
 
 .PHONY: test-all
 test-all: check-java
+	@echo "Running tests for all DBR versions..."
 	@$(MAKE) setup-all-python-versions
 	export JAVA_HOME=$(JAVA_HOME_TARGET) && \
 		export PATH=$(JAVA_HOME_TARGET)/bin:$$PATH && \
-		for env in dbr154 dbr143 dbr133 dbr122 dbr113; do hatch run $$env:test; done
+		for env in dbr154 dbr143 dbr133 dbr122 dbr113; do \
+			echo "Testing $$env..." && \
+			hatch run $$env:test || exit 1; \
+		done
+	@echo "✅ All tests passed!"
 
 # Run linters
 .PHONY: lint
@@ -422,10 +441,22 @@ coverage-report:
 	fi
 	@echo "Generating coverage report..."
 	hatch run coverage-report:run-coverage
+	@echo "✅ Coverage report generated!"
 
 
-.PHONY: all-local
-all-local: lint type-check build-dist build-docs coverage-report
+# Build both distribution and documentation
+.PHONY: build
+build: build-dist build-docs
+	@echo "✅ Build complete!"
+
+# Run complete CI pipeline
+.PHONY: ci
+ci: quality test-all build coverage-report
+	@echo "✅ Complete CI pipeline passed!"
+
+# Alias for ci
+.PHONY: all
+all: ci
 
 # Clean virtual environments and build artifacts
 .PHONY: clean

--- a/python/Makefile
+++ b/python/Makefile
@@ -86,7 +86,7 @@ setup:
 init:
 	@echo " Initializing complete development environment..."
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@$(MAKE) dev-setup
+	@$(MAKE) setup
 	@echo ""
 	@$(MAKE) check-env
 	@echo ""

--- a/python/Makefile
+++ b/python/Makefile
@@ -26,12 +26,18 @@ VENV_DIR=.venv
 VENV=$(VENV_DIR)/dbr$(DBR)
 COVERAGE_FILE=.coverage.dbr$(DBR)
 
+# Load version constraints
+-include .env.versions
+
 # Default target
 .PHONY: help
 help:
 	@echo "Makefile for managing test environments"
 	@echo ""
 	@echo "Usage:"
+	@echo "  make init                  Complete setup for new developers (recommended)"
+	@echo "  make status                Quick status check"
+	@echo "  make doctor                Run comprehensive environment health check"
 	@echo "  make check-env             Check Python and Java environment setup"
 	@echo "  make venv                  Create virtual environment for newest, supported DBR version"
 	@echo "  make venv DBR=<version>    Create virtual environment for a specific DBR version"
@@ -46,6 +52,7 @@ help:
 	@echo "  make build-docs            Build documentation"
 	@echo "  make all-local             Run all local tests and checks"
 	@echo "  make clean                 Remove all generated files"
+	@echo "  make deep-clean            Remove everything (venvs, caches, artifacts)"
 	@echo ""
 	@echo "Available Environment Versions:"
 	@echo "  154 - Python 3.11, Java 8 (default)"
@@ -59,6 +66,141 @@ help:
 	@echo "  - Java 8 (Zulu) managed via SDKMAN"
 	@echo "  - All DBR versions use Java 8 to match Databricks Runtime"
 	@echo ""
+
+# Setup development environment
+.PHONY: setup
+setup:
+	@echo "Setting up development environment..."
+	@if [ -f .env.versions ]; then \
+		. .env.versions && \
+		python -m pip install --upgrade pip --quiet && \
+		python -m pip install hatch==$${HATCH_VERSION} "$${CLICK_CONSTRAINT}" --quiet && \
+		echo "Development tools installed successfully"; \
+	else \
+		echo "ERROR: .env.versions file not found"; \
+		exit 1; \
+	fi
+
+# Complete initialization for new developers - one command to set up everything
+.PHONY: init
+init:
+	@echo " Initializing complete development environment..."
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@$(MAKE) dev-setup
+	@echo ""
+	@$(MAKE) check-env
+	@echo ""
+	@echo " Creating default virtual environment..."
+	@$(MAKE) venv
+	@echo ""
+	@echo " Running smoke test..."
+	@$(MAKE) lint 2>&1 | head -5
+	@echo ""
+	@echo " Development environment initialization complete!"
+	@echo ""
+	@echo " Next steps:"
+	@echo "  1. Review CONTRIBUTING.md for detailed documentation"
+	@echo "  2. Run 'make test' to run tests"
+	@echo "  3. Run 'make help' to see all available commands"
+
+# Quick status check
+.PHONY: status
+status:
+	@# Check development tools
+	@if [ -f .env.versions ]; then \
+		. .env.versions && \
+		if command -v hatch >/dev/null 2>&1; then \
+			HATCH_VER=$$(hatch --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); \
+			if [ "$${HATCH_VER}" = "$${HATCH_VERSION}" ] && python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)" 2>/dev/null; then \
+				echo "Development tools: OK"; \
+			else \
+				echo "Development tools: needs update (run 'make setup')"; \
+			fi; \
+		else \
+			echo "Development tools: not installed (run 'make setup')"; \
+		fi; \
+	else \
+		echo "Development tools: config missing"; \
+	fi
+	@# Check Java
+	@if [ -d "$(JAVA_HOME_TARGET)" ]; then \
+		echo "Java 8: OK"; \
+	else \
+		echo "Java 8: not installed"; \
+	fi
+	@# Check virtual environments
+	@if [ -d ".venv" ]; then \
+		COUNT=$$(ls -1 .venv | wc -l | tr -d ' '); \
+		echo "Virtual environments: $${COUNT}"; \
+	else \
+		echo "Virtual environments: none (run 'make venv')"; \
+	fi
+
+# Comprehensive environment health check
+.PHONY: doctor
+doctor:
+	@echo " Running comprehensive environment health check..."
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo " System Information:"
+	@echo "  OS: $$(uname -s) $$(uname -m)"
+	@echo "  Shell: $$SHELL"
+	@echo "  User: $$USER"
+	@echo ""
+	@echo " Python Status:"
+	@which python >/dev/null 2>&1 && echo "   python: $$(which python) ($$(python --version 2>&1))" || echo "   python: not found"
+	@which python3 >/dev/null 2>&1 && echo "   python3: $$(which python3) ($$(python3 --version 2>&1))" || echo "   python3: not found"
+	@echo ""
+	@$(MAKE) check-deps 2>&1 | sed 's/^/  /'
+	@echo ""
+	@echo " Java Status:"
+	@if [ -d "$(JAVA_HOME_TARGET)" ]; then \
+		echo "   Java 8 installed at $(JAVA_HOME_TARGET)"; \
+	else \
+		echo "    Java 8 not installed (will be installed when needed)"; \
+	fi
+	@echo ""
+	@echo " Virtual Environments:"
+	@if [ -d ".venv" ]; then \
+		for env in .venv/*; do \
+			if [ -d "$$env" ]; then \
+				echo "   $$(basename $$env)"; \
+			fi; \
+		done; \
+	else \
+		echo "    No virtual environments found"; \
+	fi
+	@echo ""
+	@echo " Diagnosis Complete"
+	@if command -v hatch >/dev/null 2>&1 && python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)" 2>/dev/null; then \
+		echo "   Environment is healthy"; \
+	else \
+		echo "    Issues detected - run 'make init' to fix"; \
+	fi
+
+# Run all code quality checks (alias for lint + type-check)
+.PHONY: quality
+quality: lint type-check
+
+
+# Deep clean - remove everything including venvs
+.PHONY: deep-clean
+deep-clean: clean
+	@echo " Deep cleaning - removing all artifacts..."
+	@rm -rf .venv/
+	@rm -rf .tox/
+	@rm -rf __pycache__/
+	@rm -rf .pytest_cache/
+	@rm -rf .mypy_cache/
+	@rm -rf .coverage*
+	@rm -rf htmlcov/
+	@rm -rf dist/
+	@rm -rf build/
+	@rm -rf *.egg-info/
+	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	@find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	@find . -type f -name "*.pyo" -delete 2>/dev/null || true
+	@echo " Deep clean complete!"
 
 # Check if Java 8 is available and install if needed
 .PHONY: check-java
@@ -119,9 +261,49 @@ check-python:
 		echo "pyenv installed successfully"; \
 	fi
 
-# Check both Python and Java environments
+# Check dependencies (hatch and click versions)
+.PHONY: check-deps
+check-deps:
+	@echo "Checking development dependencies..."
+	@if [ -f .env.versions ]; then \
+		. .env.versions && \
+		echo "Expected versions from .env.versions:" && \
+		echo "  - hatch: $${HATCH_VERSION}" && \
+		echo "  - click: < 8.3.0" && \
+		echo "" && \
+		if command -v hatch >/dev/null 2>&1; then \
+			INSTALLED_HATCH=$$(hatch --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
+			echo "Installed hatch: $${INSTALLED_HATCH}" && \
+			if [ "$${INSTALLED_HATCH}" != "$${HATCH_VERSION}" ]; then \
+				echo "  Warning: hatch version mismatch! Expected $${HATCH_VERSION}, got $${INSTALLED_HATCH}"; \
+				echo "  Run 'make setup' to install the correct version"; \
+			else \
+				echo " Hatch version is correct"; \
+			fi; \
+		else \
+			echo " hatch not found! Run 'make setup' to install"; \
+		fi && \
+		if python -c "import click" 2>/dev/null; then \
+			INSTALLED_CLICK=$$(python -c "import click; print(click.__version__)") && \
+			echo "Installed click: $${INSTALLED_CLICK}" && \
+			if python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)"; then \
+				echo "Click version is safe (< 8.3.0)"; \
+			else \
+				echo "  Warning: Click version $${INSTALLED_CLICK} may cause issues!"; \
+				echo "  See: https://github.com/pypa/hatch/issues/2050"; \
+				echo "  Run 'make setup' to install the correct version"; \
+			fi; \
+		else \
+			echo " click not found! Run 'make setup' to install"; \
+		fi; \
+	else \
+		echo " Error: .env.versions file not found"; \
+		echo "  Cannot verify dependency versions"; \
+	fi
+
+# Check both Python, Java environments, and dependencies
 .PHONY: check-env
-check-env: check-python check-java
+check-env: check-python check-java check-deps
 
 # Setup Python version for current DBR using either system Python or pyenv
 .PHONY: setup-python-versions

--- a/python/Makefile
+++ b/python/Makefile
@@ -200,7 +200,7 @@ test-all: check-java
 .PHONY: lint
 lint:
 	@echo "Running linters..."
-	hatch run lint:runLint $()
+	hatch run lint:runLint $(LINT_PARAMS)
 
 # Format code with Black
 .PHONY: format


### PR DESCRIPTION
Changes

This PR fixes CI failures caused by hatch/click 8.3.0 incompatibility and significantly streamlines the developer setup process. The changes centralize version management, simplify the Makefile, and make the development environment more maintainable.

  Key improvements:

  - Fixed CI failures: Resolved the TypeError: the JSON object must be str, bytes or bytearray, not Sentinel error in GitHub Actions
  - Centralized version management: Created .env.versions file that both local development and CI use
  - Streamlined setup: New make init command provides a one-command setup for developers
  - Better developer experience: Added make status and make doctor commands for environment health checks
  - Cleaner documentation: Consolidated DEVELOPER.md into CONTRIBUTING.md with focus on make commands
  - Simplified CI/CD: Workflows now use make setup instead of direct pip commands

  Linked issues

  Related to hatch/click incompatibility tracked in:
  - https://github.com/pypa/hatch/issues/2050
  - https://github.com/pallets/click/issues/3065

  Functionality

  - added relevant user documentation
  - added a new Class method
  - modified existing Class method: ...
  - added a new function
  - modified existing function: ...
  - added a new test
  - modified existing test: ...
  - added a new example
  - modified existing example: ...
  - added a new utility
  - modified existing utility: Makefile - streamlined commands and added new targets

  Tests

  - manually tested
  - added unit tests
  - added integration tests
  - verified on staging environment (screenshot attached)

  Manual testing performed:
  - Verified make lint works with fixed syntax
  - Tested make init, make status, and make doctor commands
  - Confirmed CI workflows will work with centralized version management on local laptop
  - Validated that all hatch commands use correct colon syntax