### PR TITLE
Chore: Remove click dependency constraint and upgrade hatch to 1.14.2

### DIFF
--- a/python/.env.versions
+++ b/python/.env.versions
@@ -1,15 +1,8 @@
 # Version constraints for development tools
 # These versions are used in both CI and local development
 # Source this file or use in scripts to ensure consistency
-#
-# TRACKING ISSUES:
-# - Hatch + Click 8.3.0 compatibility: https://github.com/pypa/hatch/issues/2050
-# - Click 8.3.0 regression: https://github.com/pallets/click/issues/3065
-#
-# Once these issues are resolved, we can upgrade to latest hatch without the click constraint
 
-HATCH_VERSION="1.9.4"
-CLICK_CONSTRAINT="click<8.3.0"
+HATCH_VERSION="1.14.2"
 
 # Full pip install command
-HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION} '${CLICK_CONSTRAINT}'"
+HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION}"

--- a/python/Makefile
+++ b/python/Makefile
@@ -87,7 +87,7 @@ setup:
 	@if [ -f .env.versions ]; then \
 		. .env.versions && \
 		python -m pip install --upgrade pip --quiet && \
-		python -m pip install hatch==$${HATCH_VERSION} "$${CLICK_CONSTRAINT}" --quiet && \
+		$${HATCH_INSTALL_CMD} --quiet && \
 		echo "Development tools installed successfully"; \
 	else \
 		echo "ERROR: .env.versions file not found"; \
@@ -124,7 +124,7 @@ status:
 		. .env.versions && \
 		if command -v hatch >/dev/null 2>&1; then \
 			HATCH_VER=$$(hatch --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); \
-			if [ "$${HATCH_VER}" = "$${HATCH_VERSION}" ] && python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)" 2>/dev/null; then \
+			if [ "$${HATCH_VER}" = "$${HATCH_VERSION}" ]; then \
 				echo "Development tools: OK"; \
 			else \
 				echo "Development tools: needs update (run 'make setup')"; \
@@ -185,7 +185,7 @@ doctor:
 	fi
 	@echo ""
 	@echo " Diagnosis Complete"
-	@if command -v hatch >/dev/null 2>&1 && python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)" 2>/dev/null; then \
+	@if command -v hatch >/dev/null 2>&1; then \
 		echo "   Environment is healthy"; \
 	else \
 		echo "    Issues detected - run 'make init' to fix"; \
@@ -275,7 +275,7 @@ check-python:
 		echo "pyenv installed successfully"; \
 	fi
 
-# Check dependencies (hatch and click versions)
+# Check dependencies (hatch version)
 .PHONY: check-deps
 check-deps:
 	@echo "Checking development dependencies..."
@@ -283,7 +283,6 @@ check-deps:
 		. .env.versions && \
 		echo "Expected versions from .env.versions:" && \
 		echo "  - hatch: $${HATCH_VERSION}" && \
-		echo "  - click: < 8.3.0" && \
 		echo "" && \
 		if command -v hatch >/dev/null 2>&1; then \
 			INSTALLED_HATCH=$$(hatch --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
@@ -296,19 +295,6 @@ check-deps:
 			fi; \
 		else \
 			echo " hatch not found! Run 'make setup' to install"; \
-		fi && \
-		if python -c "import click" 2>/dev/null; then \
-			INSTALLED_CLICK=$$(python -c "import click; print(click.__version__)") && \
-			echo "Installed click: $${INSTALLED_CLICK}" && \
-			if python -c "import click; exit(0 if tuple(map(int, click.__version__.split('.'))) < (8, 3, 0) else 1)"; then \
-				echo "Click version is safe (< 8.3.0)"; \
-			else \
-				echo "  Warning: Click version $${INSTALLED_CLICK} may cause issues!"; \
-				echo "  See: https://github.com/pypa/hatch/issues/2050"; \
-				echo "  Run 'make setup' to install the correct version"; \
-			fi; \
-		else \
-			echo " click not found! Run 'make setup' to install"; \
 		fi; \
 	else \
 		echo " Error: .env.versions file not found"; \


### PR DESCRIPTION
## Changes

  Now that [hatch#2050](https://github.com/pypa/hatch/issues/2050) and [click#3065](https://github.com/pallets/click/issues/3065) are resolved, remove the click<8.3.0 constraint and upgrade hatch from 1.9.4
  to 1.14.2 (latest stable).

  **Changes:**
  - Update `.env.versions` to use hatch 1.14.2 without click constraint
  - Simplify Makefile to use `HATCH_INSTALL_CMD` from `.env.versions`
  - Remove click version checks from `status`, `doctor`, and `check-deps` targets

  **Tested make targets:** `setup`, `status`, `check-deps`, `lint`, `format` - all passing.

  ### Linked issues

  Resolves hatch compatibility issues referenced in #447

  ### Functionality

  - [ ] added relevant user documentation
  - [ ] added a new Class method
  - [ ] modified existing Class method: `...`
  - [ ] added a new function
  - [ ] modified existing function: `...`
  - [ ] added a new test
  - [ ] modified existing test: `...`
  - [ ] added a new example
  - [ ] modified existing example: `...`
  - [x] added a new utility
  - [x] modified existing utility: `.env.versions`, `Makefile`

  ### Tests

  - [x] manually tested
  - [ ] added unit tests
  - [ ] added integration tests
  - [ ] verified on staging environment (screenshot attached)