### PR TITLE
Add skip-install to lint env and clean up version.py dead code

### DIFF
--- a/python/.env.versions
+++ b/python/.env.versions
@@ -6,4 +6,4 @@ HATCH_VERSION="1.14.2"
 
 # Full pip install command
 # Pin virtualenv<21 to work around https://github.com/pypa/hatch/issues/2193
-HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION} 'virtualenv<21'"
+HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION} virtualenv<21"

--- a/python/.env.versions
+++ b/python/.env.versions
@@ -5,4 +5,5 @@
 HATCH_VERSION="1.14.2"
 
 # Full pip install command
-HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION}"
+# Pin virtualenv<21 to work around https://github.com/pypa/hatch/issues/2193
+HATCH_INSTALL_CMD="pip install hatch==${HATCH_VERSION} 'virtualenv<21'"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -136,6 +136,7 @@ extra-dependencies = [
 [tool.hatch.envs.lint]
 path = ".venv/lint"
 template = "testenv"
+skip-install = true
 dependencies = [
   "flake8",
   "black==24.4.1"

--- a/python/version.py
+++ b/python/version.py
@@ -1,33 +1,15 @@
-import subprocess
-
 CURRENT_VERSION = "0.1.30"
-# run a shell command and return stdout
-def run_cmd(cmd):
-    cmd_proc = subprocess.run(cmd, shell=True, capture_output=True)
-    if cmd_proc.returncode != 0:
-        raise OSError(
-            f"Shell command '{cmd}' failed with return code {cmd_proc.returncode}\n"
-            f"STDERR: {cmd_proc.stderr.decode('utf-8')}"
-        )
-    return cmd_proc.stdout.decode("utf-8").strip()
 
 
-# fetch the most recent build version for hatch environment creation
 def get_version():
-    """Return the package version based on latest git tag."""
+    """Return the package version based on CURRENT_VERSION or env override."""
     import os
 
     # Optionally override with environment variable
     if "PACKAGE_VERSION" in os.environ:
         return os.environ.get("PACKAGE_VERSION")
 
-    # Fall back to git tag
-    try:
-        return CURRENT_VERSION
-    except (OSError, ValueError) as E:
-        # Return a fallback version if git operations fail
-        # TODO - Raise with error message
-        raise E
+    return CURRENT_VERSION
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Add skip-install = true to lint hatch env (no need to install the package just to run black/flake8)
- Remove unused run_cmd function and subprocess import from version.py
- Simplify get_version() by removing unnecessary try/except around a constant that can never raise OSError/ValueError

## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added a new Class method
- [ ] modified existing Class method: `...`
- [ ] added a new function
- [ ] modified existing function: `...`
- [ ] added a new test
- [ ] modified existing test: `...`
- [ ] added a new example
- [ ] modified existing example: `...`
- [ ] added a new utility
- [ ] modified existing utility: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)